### PR TITLE
Enable permissinos for controller and editor roles to use live preview.

### DIFF
--- a/modules/localgov_live_preview_microsites/localgov_live_preview_microsites.module
+++ b/modules/localgov_live_preview_microsites/localgov_live_preview_microsites.module
@@ -1,11 +1,26 @@
 <?php
 
 use Drupal\Core\EventSubscriber\MainContentViewSubscriber;
+use Drupal\localgov_microsites_group\RolesHelper;
 
 /**
  * @file
  * Primary module hooks for LocalGov Live Preview module.
  */
+
+/**
+ * Implements hook_localgov_microsites_roles_default().
+ */
+function localgov_live_preview_microsites_localgov_microsites_roles_default() {
+
+  return [
+    'global' => [
+      RolesHelper::MICROSITES_CONTROLLER_ROLE => ['use localgov live preview'],
+      RolesHelper::MICROSITES_EDITOR_ROLE => ['use localgov live preview'],
+    ],
+  ];
+
+}
 
 /**
  * Implements hook_preprocess_HOOK().


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Aims to grant the permissions to use localgov live preview when installed in microsites. 

## How to test

Try a fresh install of microsites and see if the permissions are enabled.

We're looking for this: 

![image](https://github.com/user-attachments/assets/b0c5f8b3-ac8e-4a5d-9c0d-71d63e8b12ed)
